### PR TITLE
Added option to allow direct messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To send, listen to messages, or fetch the list of channels or roles, you need to
 ## Operations
 
 With this node, you can:
-- Listen to Discord chat messages.
+- Listen to Discord chat messages (both server messages and direct messages).
 - React to messages with specific patterns or triggers.
 - Fetch lists of channels and roles.
 

--- a/nodes/DiscordInteraction/DiscordInteraction.node.ts
+++ b/nodes/DiscordInteraction/DiscordInteraction.node.ts
@@ -7,6 +7,7 @@ import {
     type INodeParameters,
     INodeOutputConfiguration,
     NodeOperationError,
+    NodeConnectionType,
 } from 'n8n-workflow';
 import { options } from './DiscordInteraction.node.options';
 import ipc from 'node-ipc';
@@ -95,7 +96,7 @@ export class DiscordInteraction implements INodeType {
             name: 'Discord Interaction',
         },
         icon: 'file:discord-logo.svg',
-        inputs: ['main'],
+        inputs: [NodeConnectionType.Main],
         outputs: `={{(${configuredOutputs})($parameter)}}`,
         credentials: [
             {
@@ -145,7 +146,7 @@ export class DiscordInteraction implements INodeType {
         // fetch credentials
         const credentials = (await this.getCredentials('discordBotTriggerApi').catch((e) => e)) as any as ICredentials;
 
-        // create connection to bot. 
+        // create connection to bot.
         await connection(credentials).catch((e) => {
             console.log(e);
             if (this.getNodeParameter('type', 0) === 'confirm') {
@@ -159,7 +160,7 @@ export class DiscordInteraction implements INodeType {
 
         if (this.getNodeParameter('type', 0) === 'confirm') {
             const returnData: INodeExecutionData[][] = [[], [], []];
-            // create connection to bot. 
+            // create connection to bot.
             await connection(credentials).catch((e) => {
                 console.log(e);
                 returnData[2] = this.getInputData();
@@ -187,16 +188,16 @@ export class DiscordInteraction implements INodeType {
                 });
             });
             console.log(response);
-        
+
             if (response.confirmed === null)
                 returnData[2] = this.getInputData();
             else if(response.confirmed === true)
                 returnData[0] = this.getInputData();
-            else 
+            else
                 returnData[1] = this.getInputData();
 
             return returnData;
-            
+
         } else {
             const returnData: INodeExecutionData[] = [];
             // iterate over all nodes

--- a/nodes/DiscordTrigger/DiscordTrigger.node.options.ts
+++ b/nodes/DiscordTrigger/DiscordTrigger.node.options.ts
@@ -65,9 +65,6 @@ export const options: INodeProperties[] = [
       show: {
         type: ['message', 'user-join', 'user-leave', 'message-reaction-add', 'message-reaction-remove', 'role-create', 'role-delete', 'role-update'],
       },
-      hide: {
-        type: ['direct-message'],
-      },
     },
     typeOptions: {
       loadOptionsMethod: 'getGuilds',
@@ -88,9 +85,6 @@ export const options: INodeProperties[] = [
       show: {
         type: ['message', 'message-reaction-add', 'message-reaction-remove'],
       },
-      hide: {
-        type: ['direct-message'],
-      },
     },
     default: [],
     description: 'Lets you select the text channels you want to listen to for triggering the workflow. If none selected, all channels will be listen to. Your credentials must be set and the bot running, you also need at least one text channel available. If you do not meet these requirements, make the changes then close and reopen the modal (the channels list is loaded when the modal opens). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
@@ -104,9 +98,6 @@ export const options: INodeProperties[] = [
     displayOptions: {
       show: {
         type: ['message', 'message-reaction-add', 'message-reaction-remove'],
-      },
-      hide: {
-        type: ['direct-message'],
       },
     },
     typeOptions: {

--- a/nodes/DiscordTrigger/DiscordTrigger.node.options.ts
+++ b/nodes/DiscordTrigger/DiscordTrigger.node.options.ts
@@ -13,6 +13,11 @@ export const options: INodeProperties[] = [
         description: 'When a message is sent in the selected channels',
       },
       {
+        name: 'Direct Message',
+        value: 'direct-message',
+        description: 'When a direct message is sent to the bot',
+      },
+      {
 				name: 'Reaction Add',
 				value: 'message-reaction-add',
 				description: 'When a reaction is added to a message on the server',
@@ -60,6 +65,9 @@ export const options: INodeProperties[] = [
       show: {
         type: ['message', 'user-join', 'user-leave', 'message-reaction-add', 'message-reaction-remove', 'role-create', 'role-delete', 'role-update'],
       },
+      hide: {
+        type: ['direct-message'],
+      },
     },
     typeOptions: {
       loadOptionsMethod: 'getGuilds',
@@ -80,6 +88,9 @@ export const options: INodeProperties[] = [
       show: {
         type: ['message', 'message-reaction-add', 'message-reaction-remove'],
       },
+      hide: {
+        type: ['direct-message'],
+      },
     },
     default: [],
     description: 'Lets you select the text channels you want to listen to for triggering the workflow. If none selected, all channels will be listen to. Your credentials must be set and the bot running, you also need at least one text channel available. If you do not meet these requirements, make the changes then close and reopen the modal (the channels list is loaded when the modal opens). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
@@ -93,6 +104,9 @@ export const options: INodeProperties[] = [
     displayOptions: {
       show: {
         type: ['message', 'message-reaction-add', 'message-reaction-remove'],
+      },
+      hide: {
+        type: ['direct-message'],
       },
     },
     typeOptions: {
@@ -122,7 +136,7 @@ export const options: INodeProperties[] = [
     type: 'options',
     displayOptions: {
       show: {
-        type: ['message'],
+        type: ['message', 'direct-message'],
       },
     },
     options: [
@@ -130,7 +144,7 @@ export const options: INodeProperties[] = [
         name: 'Bot Mention',
         value: 'botMention',
         description: 'The bot has to be mentioned somewhere in the message in order to trigger',
-      }, 
+      },
       {
         name: 'Contains',
         value: 'contain',
@@ -172,7 +186,7 @@ export const options: INodeProperties[] = [
     placeholder: 'e.g. !hello',
     displayOptions: {
       show: {
-        type: ['message'],
+        type: ['message', 'direct-message'],
         pattern: ['equal', 'start', 'contain', 'end', 'regex'],
       },
     },
@@ -186,7 +200,7 @@ export const options: INodeProperties[] = [
     type: 'boolean',
     displayOptions: {
       show: {
-        type: ['message'],
+        type: ['message', 'direct-message'],
       },
     },
 
@@ -199,7 +213,7 @@ export const options: INodeProperties[] = [
     type: 'boolean',
     displayOptions: {
       show: {
-        type: ['message'],
+        type: ['message', 'direct-message'],
       },
     },
 
@@ -240,6 +254,6 @@ export const options: INodeProperties[] = [
         default: false,
         description: "Whether this node needs to have at least one attachment to be triggered",
       },
-    ],									
+    ],
   }
 ];

--- a/nodes/DiscordTrigger/DiscordTrigger.node.ts
+++ b/nodes/DiscordTrigger/DiscordTrigger.node.ts
@@ -5,6 +5,7 @@ import {
     type ITriggerResponse,
     type INodePropertyOptions,
     NodeOperationError,
+    NodeConnectionType,
 } from 'n8n-workflow';
 import { options } from './DiscordTrigger.node.options';
 import bot from '../bot';
@@ -34,7 +35,7 @@ export class DiscordTrigger implements INodeType {
         },
         icon: 'file:discord-logo.svg',
         inputs: [],
-        outputs: ['main'],
+        outputs: [NodeConnectionType.Main],
         credentials: [
             {
                 name: 'discordBotTriggerApi',
@@ -66,7 +67,7 @@ export class DiscordTrigger implements INodeType {
                     // @ts-ignore
                     throw new NodeOperationError('Please select at least one server before choosing channels.');
                 }
-                
+
 
                 return await getRolesHelper(this, selectedGuilds).catch((e) => e) as { name: string; value: string }[];
             },
@@ -79,7 +80,7 @@ export class DiscordTrigger implements INodeType {
 
         if (!credentials?.token) {
             console.log("No token given.");
-            
+
             return {};
         }
 
@@ -94,7 +95,7 @@ export class DiscordTrigger implements INodeType {
             });
 
             console.log("registering ", this.getNode().id, "... ", parameters);
-            
+
             ipc.of.bot.emit('triggerNodeRegistered', {
                 parameters,
                 active: this.getWorkflow().active,
@@ -104,7 +105,7 @@ export class DiscordTrigger implements INodeType {
 
             ipc.of.bot.on('messageCreate', ({ message, author, guild, nodeId, messageReference, attachments, referenceAuthor }: any) => {
                 if( this.getNode().id === nodeId) {
-                    
+
                     const messageCreateOptions : any = {
                         id: message.id,
                         content: message.content,
@@ -147,7 +148,7 @@ export class DiscordTrigger implements INodeType {
                     ]);
                 }
             });
-            
+
             ipc.of.bot.on('guildMemberRemove', ({guildMember, guild, user, nodeId}) => {
                 if( this.getNode().id === nodeId) {
                     this.emit([
@@ -156,7 +157,7 @@ export class DiscordTrigger implements INodeType {
                 }
             });
 
-            
+
             ipc.of.bot.on('messageReactionAdd', ({messageReaction, message, user, guild, nodeId}) => {
                 if( this.getNode().id === nodeId) {
                     this.emit([
@@ -164,7 +165,7 @@ export class DiscordTrigger implements INodeType {
                     ]);
                 }
             });
-            
+
             ipc.of.bot.on('messageReactionRemove', ({messageReaction, message, user, guild, nodeId}) => {
                 if(this.getNode().id === nodeId) {
                     this.emit([
@@ -180,7 +181,7 @@ export class DiscordTrigger implements INodeType {
                     ]);
                 }
             });
-            
+
             ipc.of.bot.on('roleDelete', ({role, guild, nodeId}) => {
                 if( this.getNode().id === nodeId) {
                     this.emit([
@@ -188,13 +189,13 @@ export class DiscordTrigger implements INodeType {
                     ]);
                 }
             });
-            
+
             ipc.of.bot.on('roleUpdate', ({oldRole, newRole, guild, nodeId}) => {
                 if( this.getNode().id === nodeId) {
 
                     const addPrefix = (obj: any, prefix: string) =>
                         Object.fromEntries(Object.entries(obj).map(([key, value]) => [`${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`, value]));
-                      
+
                     const mergedRoleOptions: any = {
                         ...addPrefix(oldRole, "old"),
                         ...addPrefix(newRole, "new")
@@ -219,7 +220,7 @@ export class DiscordTrigger implements INodeType {
 
                 // remove the node from being executed
                 console.log("removing trigger node");
-                
+
                 delete settings.triggerNodes[this.getNode().id];
 
                 // Send message to bot process to deregister this node

--- a/nodes/bot.ts
+++ b/nodes/bot.ts
@@ -24,12 +24,14 @@ export default function () {
         intents: [
             GatewayIntentBits.Guilds,
             GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.MessageContent,
             GatewayIntentBits.GuildMembers,
             GatewayIntentBits.GuildPresences,
-            GatewayIntentBits.GuildBans,
+            GatewayIntentBits.GuildModeration,
             GatewayIntentBits.GuildMessageReactions,
             GatewayIntentBits.GuildMessageTyping,
+            GatewayIntentBits.DirectMessages,
+            GatewayIntentBits.DirectMessageReactions,
+            GatewayIntentBits.MessageContent,
         ],
         allowedMentions: {
             parse: ['roles', 'users', 'everyone'],
@@ -293,7 +295,7 @@ export default function () {
         let messageReference: Message | null = null;
         let messageRerenceFetched = !(message.reference);
 
-        // iterate through all nodes and see if we need to trigger some                
+        // iterate through all nodes and see if we need to trigger some
         for (const [nodeId, parameters] of Object.entries(settings.triggerNodes) as [string, any]) {
             try {
                 if ('message' !== parameters.type)
@@ -367,7 +369,7 @@ export default function () {
                 if ((pattern === "botMention" && botMention) || reg.test(message.content)) {
                     // Emit the message data to n8n
 
-                    // message create Options 
+                    // message create Options
                     const messageCreateOptions : any = {
                         message,
                         messageReference,
@@ -376,13 +378,13 @@ export default function () {
                         author: message.author,
                         nodeId: nodeId,
                     }
-                    
+
                     // check attachments
                     if (onlyWithAttachments && !message.attachments) continue;
-                    
+
                     console.log("attachments", message.attachments);
                     messageCreateOptions.attachments = message.attachments;
-                    
+
                     ipc.server.emit(parameters.socket, 'messageCreate', messageCreateOptions);
                 }
 

--- a/nodes/bot.ts
+++ b/nodes/bot.ts
@@ -35,7 +35,7 @@ export default function () {
         allowedMentions: {
             parse: ['roles', 'users', 'everyone'],
         },
-        partials: [Partials.Message, Partials.Channel, Partials.Reaction],
+        partials: [Partials.Message, Partials.Channel, Partials.Reaction, Partials.User],
     });
 
     ipc.config.id = 'bot';


### PR DESCRIPTION
This pull request introduces support for handling direct messages in the Discord bot, alongside several updates to improve type safety and functionality. The most significant changes include adding a new "Direct Message" trigger type, updating the bot's intents to handle direct messages, and refining the logic to differentiate between direct and guild messages.

### New Feature: Direct Message Support
* Added a new "Direct Message" trigger type to the `DiscordTrigger` node, allowing workflows to be triggered by direct messages sent to the bot. (`nodes/DiscordTrigger/DiscordTrigger.node.options.ts`: [[1]](diffhunk://#diff-a8a2d3e0534d09d8574703aae53b84aeb147bd23add7f9c2a7054410806065daR15-R19) [[2]](diffhunk://#diff-a8a2d3e0534d09d8574703aae53b84aeb147bd23add7f9c2a7054410806065daL125-R139) [[3]](diffhunk://#diff-a8a2d3e0534d09d8574703aae53b84aeb147bd23add7f9c2a7054410806065daL175-R189) [[4]](diffhunk://#diff-a8a2d3e0534d09d8574703aae53b84aeb147bd23add7f9c2a7054410806065daL189-R203) [[5]](diffhunk://#diff-a8a2d3e0534d09d8574703aae53b84aeb147bd23add7f9c2a7054410806065daL202-R216)
* Updated the bot logic to distinguish between direct messages and guild messages, ensuring correct filtering for triggers based on message type, guild, role, and channel. (`nodes/bot.ts`: [[1]](diffhunk://#diff-3b5837ab39085a3b9896805f6108f54323745c39d7682acf79bd2f50e819cd28L299-R306) [[2]](diffhunk://#diff-3b5837ab39085a3b9896805f6108f54323745c39d7682acf79bd2f50e819cd28R319-L327)

### Bot Enhancements
* Updated the bot's intents to include support for direct messages, direct message reactions, and message content. Added partials for user objects to handle direct messages properly. (`nodes/bot.ts`: [nodes/bot.tsL27-R38](diffhunk://#diff-3b5837ab39085a3b9896805f6108f54323745c39d7682acf79bd2f50e819cd28L27-R38))
* Replaced deprecated `GatewayIntentBits.GuildBans` with `GatewayIntentBits.GuildModeration` for updated Discord API compatibility. (`nodes/bot.ts`: [nodes/bot.tsL27-R38](diffhunk://#diff-3b5837ab39085a3b9896805f6108f54323745c39d7682acf79bd2f50e819cd28L27-R38))

### Type Safety Improvements
* Replaced hardcoded input/output strings with `NodeConnectionType.Main` in both `DiscordInteraction` and `DiscordTrigger` nodes to improve type safety. (`nodes/DiscordInteraction/DiscordInteraction.node.ts`: [[1]](diffhunk://#diff-01a8c96da5ce65411ea2f389f17d6323a584458a4ea17807c6a477a0664c2368L98-R99) `nodes/DiscordTrigger/DiscordTrigger.node.ts`: [[2]](diffhunk://#diff-e23014af2701950e7d4a6088f5dd362eb000ec2c9654a9d1a83ab33ada65fb8bL37-R38)

### Documentation Update
* Clarified in the `README.md` that the bot can now listen to both server messages and direct messages. (`README.md`: [README.mdL39-R39](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39))

![image](https://github.com/user-attachments/assets/e830ac39-7f4e-47f5-8b36-c1c054d7ca34)
