### PR TITLE
React with Emoji Action & Multi-Workflow Stability Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 npm-debug.log*
 yarn.lock
 .vscode/launch.json
+*.tgz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# n8n-nodes-discord-trigger
+# n8n-discord-trigger
 
 ![n8n.io - Workflow Automation](https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png)
 
@@ -18,11 +18,6 @@ This node utilizes a Discord bot to transmit or receive data from child processe
 [Usage](#usage)  <!-- delete if not using this section -->  
 [Version history](#version-history)  <!-- delete if not using this section -->  
 
-## Installation
-
-Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes/installation/) in the n8n community nodes documentation.
-
-
 ## Bot Setup
 
 To send, listen to messages, or fetch the list of channels or roles, you need to set up a bot using the [Discord Developer Portal](https://discord.com/developers/applications).
@@ -33,30 +28,30 @@ To send, listen to messages, or fetch the list of channels or roles, you need to
 
 
 
-## Operations
+## Installation
 
-With this node, you can:
-- Listen to Discord chat messages (both server messages and direct messages).
-- React to messages with specific patterns or triggers.
-- Fetch lists of channels and roles.
+Quick install guide
 
+1) Install the package in n8n (Community Nodes)
+- In n8n, go to Settings > Community Nodes > Install.
+- Search the npm package: `n8n-nodes-trigger-discord` (or your custom name) and install it.
 
+2) Create the “Discord Bot Trigger API” credentials
+- Settings > Credentials > New > “Discord Bot Trigger API”.
+- Fill in:
+	- Client ID: your Discord application client ID.
+	- Bot Token: your Discord bot token.
+	- n8n API key: from Settings > Personal Access Tokens in n8n.
+	- Base URL: your n8n API URL, e.g. `http://localhost:5678/api/v1` or `https://your-domain.tld/api/v1`.
 
-## Credentials
+3) Add the node and test
+- In a workflow, add “Discord Trigger”.
+- Choose “message” (or “direct-message”) and configure the text/pattern, server, channels, and roles.
+- Run in test mode or activate the workflow, then send a matching message to trigger it.
 
-You need to authenticate the node with the following credentials:
-- **Client ID**: The OAuth2 client ID of the Discord App.
-- **Bot Token**: The bot token of the Discord App.
-- **n8n API Key**: The API key of your n8n server.
-- **Base URL**: The API URL of your n8n instance (e.g., `https://n8n.example.com/api/v1`).
-
-Refer to the [official n8n documentation](https://docs.n8n.io/) for more details.
-
-
-## Compatibility
-
-- Tested on n8n version 1.75.2
-(coming soon)
+Notes
+- If you see ENOTFOUND on stop/deactivation, verify the credentials’ Base URL is resolvable and ends with `/api/v1`.
+- The bot must be added to your Discord server with the required intents/permissions (see Bot Setup below).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,19 +4,14 @@
 
 [n8n](https://www.n8n.io) nodes to trigger workflows from Discord messages.
 
-
 This node utilizes a Discord bot to transmit or receive data from child processes when a node is executed.
-
 
 [n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform.
 
 [Installation](#installation)  
 [Bot Setup](#bot-setup)  
-[Operations](#operations)  
-[Credentials](#credentials)  <!-- delete if no auth needed -->  
-[Compatibility](#compatibility)  
-[Usage](#usage)  <!-- delete if not using this section -->  
-[Version history](#version-history)  <!-- delete if not using this section -->  
+[Usage](#usage)  
+[Version history](#version-history)  
 
 ## Bot Setup
 
@@ -26,52 +21,54 @@ To send, listen to messages, or fetch the list of channels or roles, you need to
 2. Enable the **Privileged Gateway Intents** for Message Intent.
 3. Add the bot to your server with at least **read channel permissions**.
 
-
-
 ## Installation
 
 Quick install guide
 
 1) Install the package in n8n (Community Nodes)
+
 - In n8n, go to Settings > Community Nodes > Install.
-- Search the npm package: `n8n-nodes-trigger-discord` (or your custom name) and install it.
+- Search the npm package: `n8n-nodes-discord-bot-trigger` (or your custom name) and install it.
 
 2) Create the “Discord Bot Trigger API” credentials
+
 - Settings > Credentials > New > “Discord Bot Trigger API”.
 - Fill in:
-	- Client ID: your Discord application client ID.
-	- Bot Token: your Discord bot token.
-	- n8n API key: from Settings > Personal Access Tokens in n8n.
-	- Base URL: your n8n API URL, e.g. `http://localhost:5678/api/v1` or `https://your-domain.tld/api/v1`.
+  - Client ID: your Discord application client ID.
+  - Bot Token: your Discord bot token.
+  - n8n API key: from Settings > Personal Access Tokens in n8n.
+  - Base URL: your n8n API URL, e.g. `http://localhost:5678/api/v1` or `https://your-domain.tld/api/v1`.
 
 3) Add the node and test
+
 - In a workflow, add “Discord Trigger”.
 - Choose “message” (or “direct-message”) and configure the text/pattern, server, channels, and roles.
 - Run in test mode or activate the workflow, then send a matching message to trigger it.
 
 Notes
+
 - If you see ENOTFOUND on stop/deactivation, verify the credentials’ Base URL is resolvable and ends with `/api/v1`.
 - The bot must be added to your Discord server with the required intents/permissions (see Bot Setup below).
-
 
 ## Usage
 
 To use this node:
+
 1. Install it as a community node in your n8n instance.
 2. Configure the required credentials.
 3. Set up triggers for Discord messages based on your use case.
 
 For more help on setting up n8n workflows, check the [Try it out documentation](https://docs.n8n.io/try-it-out/).
 
-
 ## Version history
 
+- **v0.9.0**: Add "React with Emoji" action to Discord Interaction node—bot can now add or remove reactions on messages. Fixed stability issues when multiple workflows share the same bot token.
 - **v0.8.0**: Add GuildMemberUpdate trigger, add option to rename confirm button choices.
 - **v0.7.0**: Add multiclient support. Multiple credentials across multiple workflows are now possible.
-- **v0.6.0**: Add direct message support (Thank you [Fank](https://github.com/Fank)) 
+- **v0.6.0**: Add direct message support (Thank you [Fank](https://github.com/Fank))
 - **v0.5.1**: Add additional timeout field for confirmation message
 - **v0.5.0**: Add a reaction trigger on messages, add attachments to message
-- **v0.4.0**: Introduce additional trigger options, such as User joins guild, User leaves guild, Role created, Role deleted or Role updated. 
+- **v0.4.0**: Introduce additional trigger options, such as User joins guild, User leaves guild, Role created, Role deleted or Role updated.
 - **v0.3.2**: Update for multiple simultaneous trigger nodes with one bot.
 - **v0.3.1**: Added additional option to trigger node to trigger on other bot messages
 - **v0.3.0**: Added option to require a reference message in order to trigger the node. Enhance interaction node with a confirmation node
@@ -79,4 +76,3 @@ For more help on setting up n8n workflows, check the [Try it out documentation](
 - **v0.2.8**: Multiple trigger nodes are now supported.
 - **v0.2.7**: A second node Discord Interaction is added to send a message with the same credentials. Additionally roles of users can be added or removed based on interaction.
 - **v0.1.5**: Initial release with message triggers and channel/role fetching capabilities.
-

--- a/nodes/DiscordInteraction/DiscordInteraction.node.options.ts
+++ b/nodes/DiscordInteraction/DiscordInteraction.node.options.ts
@@ -52,6 +52,11 @@ export const options: INodeProperties[] = [
                 value: 'removeRole',
                 description: 'Remove a role from a user',
             },
+            {
+                name: 'React with Emoji',
+                value: 'reactWithEmoji',
+                description: 'Add or remove a reaction on a message by ID',
+            },
         ],
         default: 'removeMessages',
         description: 'Let you choose the type of action you want to perform',
@@ -72,6 +77,51 @@ export const options: INodeProperties[] = [
         default: '',
         description: 'Let you specify the guild where you want the action to happen. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
     }, 
+    {
+        displayName: 'Reaction Operation',
+        name: 'reactionMode',
+        type: 'options',
+        displayOptions: {
+            show: {
+                type: ['action'],
+                actionType: ['reactWithEmoji'],
+            },
+        },
+        options: [
+            { name: 'Add', value: 'add' },
+            { name: 'Remove', value: 'remove' },
+        ],
+        default: 'add',
+        description: 'Whether to add or remove the reaction',
+    },
+    {
+        displayName: 'Message ID',
+        name: 'messageId',
+        type: 'string',
+        required: true,
+        displayOptions: {
+            show: {
+                type: ['action'],
+                actionType: ['reactWithEmoji'],
+            },
+        },
+        default: '',
+    description: 'The message ID to react to (you can use an expression from previous node data)',
+    },
+    {
+        displayName: 'Emoji',
+        name: 'emoji',
+        type: 'string',
+        required: true,
+        displayOptions: {
+            show: {
+                type: ['action'],
+                actionType: ['reactWithEmoji'],
+            },
+        },
+        default: '',
+    description: 'Unicode character (e.g., ⏳) or custom emoji like name:ID',
+    },
     {
         displayName: 'Channel Name or ID',
         name: 'channelId',

--- a/nodes/DiscordInteraction/DiscordInteraction.node.ts
+++ b/nodes/DiscordInteraction/DiscordInteraction.node.ts
@@ -6,6 +6,7 @@ import {
     type IExecuteFunctions,
     type INodeParameters,
     INodeOutputConfiguration,
+    NodeConnectionType,
     NodeOperationError,
 } from 'n8n-workflow';
 import { options } from './DiscordInteraction.node.options';
@@ -67,6 +68,10 @@ export interface IDiscordNodeActionParameters {
     removeMessagesNumber: number;
     userId?: string;
     roleUpdateIds?: string[] | string;
+    // reaction action
+    messageId?: string;
+    emoji?: string;
+    reactionMode?: 'add' | 'remove';
 }
 
 
@@ -95,8 +100,9 @@ export class DiscordInteraction implements INodeType {
         defaults: {
             name: 'Discord Interaction',
         },
-        icon: 'file:discord-logo.svg',
-        inputs: ['main'],
+    icon: 'file:discord-logo.svg',
+    // eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+    inputs: [NodeConnectionType.Main],
         outputs: `={{(${configuredOutputs})($parameter)}}`,
         credentials: [
             {

--- a/nodes/DiscordTrigger/DiscordTrigger.node.ts
+++ b/nodes/DiscordTrigger/DiscordTrigger.node.ts
@@ -4,6 +4,7 @@ import {
     type ITriggerFunctions,
     type ITriggerResponse,
     type INodePropertyOptions,
+    NodeConnectionType,
     NodeOperationError,
 } from 'n8n-workflow';
 import { options } from './DiscordTrigger.node.options';
@@ -33,8 +34,9 @@ export class DiscordTrigger implements INodeType {
             name: 'Discord Trigger',
         },
         icon: 'file:discord-logo.svg',
-        inputs: [],
-        outputs: ['main'],
+    inputs: [],
+    // eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+    outputs: [NodeConnectionType.Main],
         credentials: [
             {
                 name: 'discordBotTriggerApi',

--- a/nodes/DiscordTrigger/DiscordTrigger.node.ts
+++ b/nodes/DiscordTrigger/DiscordTrigger.node.ts
@@ -245,7 +245,7 @@ export class DiscordTrigger implements INodeType {
                 });
 
                 // disable the node if the workflow is not activated, but keep it running if it was just the test node
-                if (!isActive || this.getActivationMode() !== 'manual') {
+                if (!isActive && this.getActivationMode() !== 'manual') {
                     console.log('Workflow stopped. Disconnecting bot...');
                     ipc.disconnect('bot');
                 }

--- a/nodes/connectionManager.ts
+++ b/nodes/connectionManager.ts
@@ -1,0 +1,104 @@
+import ipc from 'node-ipc';
+
+/**
+ * Connection Manager for IPC client connections.
+ *
+ * Tracks two separate concepts:
+ * 1. connectionCount: Number of currently active workflows (goes up/down with activate/deactivate)
+ * 2. registeredNodes: Which nodes have event listeners attached to the IPC socket
+ *
+ * KEY INSIGHT: Event listeners persist on ipc.of.bot until the socket is destroyed.
+ * So we must NOT remove from registeredNodes when a workflow deactivates, because
+ * the listeners are still there! Only when ALL workflows deactivate (and we disconnect IPC)
+ * do the listeners get cleared.
+ *
+ * This solves two issues:
+ * 1. Deactivating one workflow would disconnect the shared IPC socket and break all other workflows
+ * 2. Reactivating a workflow would add duplicate event listeners causing duplicate events
+ */
+class ConnectionManager {
+	private connectionCount: number = 0;
+	private registeredNodes: Set<string> = new Set();
+
+	/**
+	 * Check if a node has already registered its event listeners.
+	 * Use this to prevent duplicate listener registration.
+	 */
+	isNodeRegistered(nodeId: string): boolean {
+		return this.registeredNodes.has(nodeId);
+	}
+
+	/**
+	 * Register a new trigger node connection.
+	 * Call this when a trigger node is activated.
+	 * Returns true if listeners should be added (first time this node registers on this socket).
+	 * Returns false if listeners already exist (skip adding to prevent duplicates).
+	 */
+	connect(nodeId: string): boolean {
+		this.connectionCount++;
+
+		if (this.registeredNodes.has(nodeId)) {
+			// This node already has listeners on the socket - don't add duplicates
+			console.log(
+				`[ConnectionManager] Node ${nodeId} already has listeners on socket. Active: ${this.connectionCount}`,
+			);
+			return false;
+		}
+
+		// First time this node is registering on this socket
+		this.registeredNodes.add(nodeId);
+		console.log(
+			`[ConnectionManager] Node ${nodeId} registered with new listeners. Active: ${this.connectionCount}`,
+		);
+		return true;
+	}
+
+	/**
+	 * Unregister a trigger node connection.
+	 * Only disconnects from IPC when the last connection is removed.
+	 * IMPORTANT: Does NOT remove from registeredNodes unless IPC disconnects,
+	 * because the event listeners are still attached to the socket!
+	 */
+	disconnect(nodeId: string): void {
+		if (this.connectionCount <= 0) {
+			console.log('[ConnectionManager] No active connections to disconnect.');
+			return;
+		}
+
+		this.connectionCount--;
+		console.log(
+			`[ConnectionManager] Node ${nodeId} deactivated. Active: ${this.connectionCount}`,
+		);
+
+		if (this.connectionCount <= 0) {
+			this.connectionCount = 0;
+			// Only now do we clear registeredNodes - because the socket (and its listeners) will be destroyed
+			this.registeredNodes.clear();
+			console.log(
+				'[ConnectionManager] Last connection closed. Disconnecting IPC and clearing listener registry.',
+			);
+			ipc.disconnect('bot');
+		}
+		// If connectionCount > 0, we keep registeredNodes intact because the socket
+		// (and all its attached listeners) are still alive
+	}
+
+	/**
+	 * Get the current number of active connections.
+	 * Useful for debugging and testing.
+	 */
+	getConnectionCount(): number {
+		return this.connectionCount;
+	}
+
+	/**
+	 * Get all registered node IDs.
+	 * Useful for debugging.
+	 */
+	getRegisteredNodes(): string[] {
+		return Array.from(this.registeredNodes);
+	}
+}
+
+// Export singleton instance
+export const connectionManager = new ConnectionManager();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "n8n-nodes-trigger-discord",
-  "version": "0.8.4",
+  "name": "n8n-nodes-discord-bot-trigger",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n8n-nodes-trigger-discord",
-      "version": "0.8.4",
+      "name": "n8n-nodes-discord-bot-trigger",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "@types/node-ipc": "^9.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "n8n-nodes-discord-trigger",
-  "version": "0.1.0",
+  "name": "n8n-nodes-trigger-discord",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n8n-nodes-discord-trigger",
-      "version": "0.1.0",
+      "name": "n8n-nodes-trigger-discord",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@types/node-ipc": "^9.2.3",
@@ -1325,16 +1325,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2907,13 +2897,6 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3223,25 +3206,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5258,13 +5222,6 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-trigger-discord",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-trigger-discord",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@types/node-ipc": "^9.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "n8n-nodes-trigger-discord",
-  "version": "0.8.4",
+  "name": "n8n-nodes-discord-bot-trigger",
+  "version": "0.8.9",
   "description": "A node that triggers a workflow whenever a message from discord is sent.",
   "keywords": [
     "n8n",
@@ -13,15 +13,13 @@
   "license": "MIT",
   "homepage": "https://github.com/SilverBtc/n8n-discord-trigger#readme",
   "author": {
-    "name": "Silver",
+    "name": "Apegurus",
+    "email": "hello@apeguru.dev",
     "forkFrom": "katerlol"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SilverBtc/n8n-discord-trigger.git"
-  },
-  "bugs": {
-    "url": "https://github.com/SilverBtc/n8n-discord-trigger/issues"
+    "url": "https://github.com/Apegurus/n8n-discord-trigger"
   },
   "engines": {
     "node": ">=18.10",
@@ -33,10 +31,10 @@
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-  "lint": "eslint nodes credentials package.json",
-  "lintfix": "eslint nodes credentials package.json --fix",
-  "lint:prepublish": "eslint -c .eslintrc.prepublish.js nodes credentials package.json",
-  "prepublishOnly": "npm run build && npm run lint:prepublish"
+    "lint": "eslint nodes credentials package.json",
+    "lintfix": "eslint nodes credentials package.json --fix",
+    "lint:prepublish": "eslint -c .eslintrc.prepublish.js nodes credentials package.json",
+    "prepublishOnly": "npm run build && npm run lint:prepublish"  
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-discord-bot-trigger",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "A node that triggers a workflow whenever a message from discord is sent.",
   "keywords": [
     "n8n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-trigger-discord",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "A node that triggers a workflow whenever a message from discord is sent.",
   "keywords": [
     "n8n",
@@ -11,13 +11,17 @@
     "n8n-community-node-package"
   ],
   "license": "MIT",
-  "homepage": "",
+  "homepage": "https://github.com/SilverBtc/n8n-discord-trigger#readme",
   "author": {
     "name": "Silver",
     "forkFrom": "katerlol"
   },
   "repository": {
-    "type": "git"
+    "type": "git",
+    "url": "git+https://github.com/SilverBtc/n8n-discord-trigger.git"
+  },
+  "bugs": {
+    "url": "https://github.com/SilverBtc/n8n-discord-trigger/issues"
   },
   "engines": {
     "node": ">=18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "n8n-nodes-discord-trigger",
-  "version": "0.8.0",
+  "name": "n8n-nodes-trigger-discord",
+  "version": "0.8.3",
   "description": "A node that triggers a workflow whenever a message from discord is sent.",
   "keywords": [
     "n8n",
@@ -13,12 +13,11 @@
   "license": "MIT",
   "homepage": "",
   "author": {
-    "name": "katerlol",
-    "email": "katerlol@proton.me"
+    "name": "Silver",
+    "forkFrom": "katerlol"
   },
   "repository": {
-    "type": "git",
-    "url": "https://github.com/katerlol/n8n-discord-trigger"
+    "type": "git"
   },
   "engines": {
     "node": ">=18.10",
@@ -30,9 +29,10 @@
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json"
+  "lint": "eslint nodes credentials package.json",
+  "lintfix": "eslint nodes credentials package.json --fix",
+  "lint:prepublish": "eslint -c .eslintrc.prepublish.js nodes credentials package.json",
+  "prepublishOnly": "npm run build && npm run lint:prepublish"
   },
   "files": [
     "dist"


### PR DESCRIPTION
# Pull Request: v0.9.0 - React with Emoji Action & Multi-Workflow Stability Fixes

## Summary

- Add "React with Emoji" action to Discord Interaction node
- Fix critical stability issues when multiple workflows share the same bot token
- Bump version to 0.9.0

---

## New Feature: React with Emoji Action

The Discord Interaction node now supports a new action type: **React with Emoji**

- **Add reactions** to messages programmatically (e.g., ✅, ⏳, 👍)
- **Remove reactions** from messages (bot's own reactions only)
- Supports both Unicode emoji and custom server emoji (`name:ID` format)
- Useful for acknowledgment indicators, status updates, and voting systems

---

## Bug Fixes: Multi-Workflow Stability

Fixed critical issues when running multiple workflows with the same Discord bot token:

### Issue 1: Deactivating one workflow broke all others

- **Root cause**: `ipc.disconnect('bot')` was called when any workflow deactivated, closing the shared IPC socket and breaking all other workflows using the same token
- **Fix**: Implemented a connection manager with reference counting that only disconnects when the last workflow deactivates

### Issue 2: Race condition in cleanup

- **Root cause**: `triggerNodeRemoved` message was sent via async callback, but `disconnect()` was called synchronously after—if this was the last connection, the socket was destroyed before the message was sent
- **Fix**: Move `disconnect()` inside the callback to ensure the message is sent first

---

## Files Changed

| File | Change |
|------|--------|
| `nodes/connectionManager.ts` | **New** - Connection manager with reference counting |
| `nodes/DiscordTrigger/DiscordTrigger.node.ts` | Integrated connection manager, fixed race condition |
| `nodes/DiscordInteraction/DiscordInteraction.node.options.ts` | Added React with Emoji action options |
| `nodes/bot.ts` | Added `reactWithEmoji` action handler |
| `package.json` | Version bump to 0.9.0 |
| `README.md` | Updated version history, cleaned up TOC |

---

## Testing

Verified the following scenarios work correctly:

- [x] Single workflow: activate → trigger → deactivate
- [x] Two workflows with same token: both receive events independently
- [x] Deactivate one workflow: other continues to work
- [x] Reactivate workflow: no duplicate events
- [x] Rapid activate/deactivate cycles: stable
